### PR TITLE
New Digest Format

### DIFF
--- a/digest.js
+++ b/digest.js
@@ -38,7 +38,7 @@ const sendDigest = async (oldEmojis, newEmojis) => {
     const random = meow_emojis[Math.floor(Math.random()*meow_emojis.length)];
     msg = `There are *no new emojis* to discover today :meow_sad:, but here's one of my favorites: :${random}:`
   } else {
-    const emojis = newEmojis.map((emoji) => `:${emoji}:`).join(' ');
+    const emojis = newEmojis.map((emoji) => `:${emoji}: — \`:${emoji}:\``).join('\n');
     msg = `There are *${newEmojis.length}* new emojis today! :meow_happy_paws:
 ${emojis}`;
   }


### PR DESCRIPTION
When we have a bunch of new emojis it looks like this:

<img width="452" alt="Screen Shot 2019-09-17 at 12 21 39 PM" src="https://user-images.githubusercontent.com/587702/65060382-bee28d80-d945-11e9-8eef-39658d24397c.png">

This is a _little_ crowded, so lets break them each onto a new line so they have some room to breathe. With that new real estate, we can also add in the `:shortcut:` for the emoji. This should make it a little easier to learn how to _use_ an emoji for everyone, but in particular mobile users who can't "hover" over them.

<img width="313" alt="Screen Shot 2019-09-17 at 12 23 37 PM" src="https://user-images.githubusercontent.com/587702/65060519-023cfc00-d946-11e9-96d9-45cbc0dc8558.png">

✨ 