### PR TITLE
[refactor] Break out utilities into separate files

### DIFF
--- a/digest.js
+++ b/digest.js
@@ -1,70 +1,18 @@
-// slack dependencies
-const { IncomingWebhook } = require("@slack/webhook");
-const { WebClient } = require('@slack/web-api');
-const url = process.env.SLACK_WEBHOOK_URL;
-const token = process.env.SLACK_TOKEN;
-const slack_web = new WebClient(token);
-const slack_webhook = new IncomingWebhook(url);
 
-// redis dependencies
-const redis = require('redis').createClient(process.env.REDIS_URL);
-const { promisify } = require('util');
-const get = promisify(redis.get).bind(redis); // this maps redis.get(key, callback(results)) to a promise-compatible function
-const moment = require('moment');
-
-const getEmojisForDate = async (key) => {
-  const response = await get(key);
-
-  return JSON.parse(response);
-}
-
-const getNewEmojis = (current, yesterdays) => {
-  if (!current || !yesterdays) { // if either group of emojis don't come back, don't bother trying to parse it.
-    return [];
-  }
-
-  return current.filter((emoji) => {
-    // filter the emojis down to just the new ones by comparing the current list to yesterdays list
-    return yesterdays.indexOf(emoji) == -1;
-  })
-}
-
-const sendDigest = async (oldEmojis, newEmojis) => {
-  let msg = '';
-
-  if (newEmojis.length === 0) {
-    // if there are no new emojis, give them a random (meow) emoji
-    const meow_emojis = oldEmojis.filter((e) => e.includes('meow_'));
-    const random = meow_emojis[Math.floor(Math.random()*meow_emojis.length)];
-    msg = `There are *no new emojis* to discover today :meow_sad:, but here's one of my favorites: :${random}:`
-  } else {
-    const emojis = newEmojis.map((emoji) => `:${emoji}:`).join(' ');
-    msg = `There are *${newEmojis.length}* new emojis today! :meow_happy_paws:
-${emojis}`;
-  }
-
-  await slack_webhook.send({
-    text: msg
-  });
-}
+const { synchronizeEmojis } = require('./lib/persist');
+const { getDifference } = require('./lib/parse');
+const { sendDigest, sendRandomEmoji } = require('./lib/msg');
 
 (async () => {
-  const today = moment();
-  const yesterday = moment().subtract(1, 'day');
+  // get both sets of emojis so we can compare
+  const { today, yesterday } = await synchronizeEmojis();
 
-  const slack_response = await slack_web.apiCall("emoji.list");
-  // slack returns emojis as an object, { 'meow_json': 'url_to_image_asset' }
-  // we only really need the object keys
-  const currentEmojis = Object.keys(slack_response.emoji);
-  const yesterdaysEmojis = await getEmojisForDate(yesterday.format('MM-DD-YYYY'));
+  const difference = getDifference(today, yesterday);
+  const newEmojis = Object.keys(difference);
 
-  // create a "key" based on the date to store todays emoji list under, ex: '09-13-2019: [ meow_array, meow_string, meow_object ]
-  const key = today.format('MM-DD-YYYY');
-  redis.set(key, JSON.stringify(currentEmojis));
+  if (!newEmojis) {
+    return await sendRandomEmoji(today).then(() => process.exit());
+  }
 
-  const newEmojis = getNewEmojis(currentEmojis, yesterdaysEmojis);
-
-  await sendDigest(currentEmojis, newEmojis);
-
-  process.exit();
+  return await sendDigest(newEmojis).then(() => process.exit());
 })();

--- a/lib/msg.js
+++ b/lib/msg.js
@@ -1,0 +1,22 @@
+const { send } = require('./slack');
+
+const sendDigest = async (newEmojis) => {
+  const emojis = newEmojis.map((emoji) => `:${emoji}: — \`:${emoji}:\``).join('\n');
+  msg = `There are *${newEmojis.length}* new emojis today! :meow_happy_paws: \n${emojis}`;
+
+  return await send(msg);
+}
+
+const sendRandomEmoji = async (emojis) => {
+  // if there are no new emojis, give them a random (meow) emoji
+  const meow_emojis = Object.keys(emojis).filter((e) => e.includes('meow_'));
+  const random = meow_emojis[Math.floor(Math.random()*meow_emojis.length)];
+  msg = `There are *no new emojis* to discover today :meow_sad:, but here's one of my favorites: :${random}:`
+
+  return await send(msg);
+}
+
+module.exports = {
+  sendDigest,
+  sendRandomEmoji
+}

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,0 +1,20 @@
+const getDifference = (current, yesterdays) => {
+  if (!current || !yesterdays) { // if either group of emojis don't come back, don't bother trying to parse it.
+    return null;
+  }
+
+  return Object.keys(current).reduce((difference, emoji) => {
+    if (Object.keys(yesterdays).includes(emoji)) {
+      return difference;
+    }
+
+    return {
+      ...difference,
+      [emoji]: current[emoji]
+    }
+  }, {});
+}
+
+module.exports = {
+  getDifference
+}

--- a/lib/persist.js
+++ b/lib/persist.js
@@ -11,7 +11,7 @@ const synchronizeEmojis = async () => {
   // store that list
   const today = moment();
   const todayKey = today.format('MM-DD-YYYY');
-  // redis.set(todayKey, JSON.stringify(currentEmojis));
+  redis.set(todayKey, JSON.stringify(currentEmojis));
 
   // what emojis did we have yesterday?
   const yesterday = moment().subtract(1, 'day');

--- a/lib/persist.js
+++ b/lib/persist.js
@@ -1,0 +1,36 @@
+const redis = require('redis').createClient(process.env.REDIS_URL);
+const { promisify } = require('util');
+const get = promisify(redis.get).bind(redis); // this maps redis.get(key, callback(results)) to a promise-compatible function
+const moment = require('moment');
+const { getCurrentEmojis } = require('./slack');
+
+const synchronizeEmojis = async () => {
+  // what emojis are present _right now_?
+  const currentEmojis = await getCurrentEmojis();
+
+  // store that list
+  const today = moment();
+  const todayKey = today.format('MM-DD-YYYY');
+  // redis.set(todayKey, JSON.stringify(currentEmojis));
+
+  // what emojis did we have yesterday?
+  const yesterday = moment().subtract(1, 'day');
+  const yesterdayKey = yesterday.format('MM-DD-YYYY');
+  let yesterdaysEmojis = JSON.parse(await get(yesterdayKey));
+  if (Array.isArray(yesterdaysEmojis)) {
+    // legacy data, make it an object so we can parse it (even if we lose fidelity)
+    yesterdaysEmojis = yesterdaysEmojis.reduce((emojis, emoji) => {
+      return {
+        ...emojis,
+        [emoji]: ''
+      }
+    }, {});
+  }
+
+  // return both for processing
+  return { today: currentEmojis, yesterday: yesterdaysEmojis };
+}
+
+module.exports = {
+  synchronizeEmojis: synchronizeEmojis
+}

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -1,0 +1,29 @@
+
+const { WebClient } = require('@slack/web-api');
+const token = process.env.SLACK_TOKEN;
+const slack_web = new WebClient(token);
+
+const { IncomingWebhook } = require("@slack/webhook");
+const url = process.env.SLACK_WEBHOOK_URL;
+const slack_webhook = new IncomingWebhook(url);
+
+const getCurrentEmojis = async () => {
+  return await slack_web.apiCall("emoji.list").then((response) => {
+    if (!response.ok) {
+      return [];
+    }
+
+    return response.emoji;
+  });
+}
+
+const send = async (msg) => {
+  return await slack_webhook.send({
+    text: msg
+  });
+}
+
+module.exports = {
+  getCurrentEmojis,
+  send
+}


### PR DESCRIPTION
Everything is sort of _in_ digest, so it's a bit hard to grok what's going on at a high level. This change simplifies what's visible in that file by abstracting away the magic. I'm hoping this also allows unit testing to happen eventually.

In order to to do #2 it will be necessary to have a testing framework in place so we can simulate aliases coming in and deal with them (mocking slack, redis trickery, sound like hell so this is preferred)