### PR TITLE
Show large versions of the emojis

### DIFF
--- a/digest.js
+++ b/digest.js
@@ -14,5 +14,5 @@ const { sendDigest, sendRandomEmoji } = require('./lib/msg');
     return await sendRandomEmoji(today).then(() => process.exit());
   }
 
-  return await sendDigest(newEmojis).then(() => process.exit());
+  return await sendDigest(difference).then(() => process.exit());
 })();

--- a/lib/msg.js
+++ b/lib/msg.js
@@ -1,10 +1,53 @@
-const { send } = require('./slack');
+const { sendMsg, sendBlocks } = require('./slack');
 
 const sendDigest = async (newEmojis) => {
-  const emojis = newEmojis.map((emoji) => `:${emoji}: — \`:${emoji}:\``).join('\n');
-  msg = `There are *${newEmojis.length}* new emojis today! :meow_happy_paws: \n${emojis}`;
+  const emojis = Object.keys(newEmojis).map((emoji) => {
+    if (newEmojis[emoji].includes('alias:')) {
+      return {
+        "type": "section",
+        "text": {
+          "type": "mrkdwn",
+          "text": `:${emoji}: — \`:${emoji}:\` (alias for \`:${newEmojis[emoji].split(':')[1]}:\`)`
+        }
+      }
+    }
 
-  return await send(msg);
+    return {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": `:${emoji}: — \`:${emoji}:\``
+      },
+      "accessory": {
+        "type": "image",
+        "image_url": newEmojis[emoji],
+        "alt_text": `emoji image for :${emoji}:`
+      }
+    }
+  }).sort((a, b) => {
+    if (!a['accessory'] && b['accessory']) {
+      return 1;
+    }
+
+    if (a['accessory'] && !b['accessory']) {
+      return -1;
+    }
+
+    return 0;
+  });
+
+  const blocks = [
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": `There are *${Object.keys(newEmojis).length}* new emojis today! :meow_happy_paws:`
+      }
+    },
+    ...emojis
+  ];
+
+  return await sendBlocks(blocks);
 }
 
 const sendRandomEmoji = async (emojis) => {
@@ -13,7 +56,7 @@ const sendRandomEmoji = async (emojis) => {
   const random = meow_emojis[Math.floor(Math.random()*meow_emojis.length)];
   msg = `There are *no new emojis* to discover today :meow_sad:, but here's one of my favorites: :${random}:`
 
-  return await send(msg);
+  return await sendMsg(msg);
 }
 
 module.exports = {

--- a/lib/slack.js
+++ b/lib/slack.js
@@ -17,13 +17,20 @@ const getCurrentEmojis = async () => {
   });
 }
 
-const send = async (msg) => {
+const sendBlocks = async (blocks) => {
+  return await slack_webhook.send({
+    "blocks": blocks
+  }).catch((err) => console.log(err));
+}
+
+const sendMsg = async (msg) => {
   return await slack_webhook.send({
     text: msg
-  });
+  })
 }
 
 module.exports = {
   getCurrentEmojis,
-  send
+  sendBlocks,
+  sendMsg
 }


### PR DESCRIPTION
It's _hard_ to see the emojis in their glory when you're on mobile or even on desktop if you're not zoomed in. This bot is about celebrating the emojis, so let's show them off.

This change refactors the digest formatting to use Slack [blocks](https://api.slack.com/reference/block-kit/blocks) to "attach" an image to each emoji. Conveniently, slack already provides the URL to the emoji in their API response, so we can just pass that as our image. No juggling images!

The exception to the above is aliases, which have long plagued me. In the case of aliases, a reference to the _original_ emoji is provided. Not the URL. We could get fancy and look up that URL, but for the purpose of this change I'm just conditionally rendering a lower-fidelity "block" without the large image. I take the opportunity to mention that it's an alias and give folks a reference to the original, too. I also sorted "alias" blocks to the bottom so we don't get unusual gaps in the layout. 

<img width="712" alt="Screen Shot 2019-09-27 at 3 03 04 PM" src="https://user-images.githubusercontent.com/587702/65795294-ef8da880-e137-11e9-9f1e-c53e53daa76f.png">
