### PR TITLE
Filter out values that contain 'alias'

### DIFF
--- a/lib/persist.js
+++ b/lib/persist.js
@@ -43,11 +43,11 @@ const getRandomMeow = async () => {
   const redis = await makeRedisClient();
   const emojis = await redis.get("last_known");
   const emoji_json = JSON.parse(emojis);
-  const meow_emojis = Object.keys(emoji_json).filter((e) =>
-    e.includes("meow")
+  const emoji_array = Object.entries(emoji_json);
+  const meow_emojis = emoji_array.filter(([key, value]) => 
+    key.includes("meow") && !value.includes("alias")
   );
-  const random = meow_emojis[Math.floor(Math.random() * meow_emojis.length)];
-
+  const random = meow_emojis[Math.floor(Math.random() * meow_emojis.length)][0];
   return random;
 };
 


### PR DESCRIPTION
I did a thing on my own branch of emoji club and I thought I should share it with the papa branch. I turned the emoji json into an array of of arrays containing the keys and values so I could use the filter function on both of those parts. This change filters by "meow" as normal, but also filters out any values that contain the word "alias". Unfortunately, I couldn't figure out how to console log the random const to verify it works as normal, so please give that a look and let me know how I might do that if you have a minute.